### PR TITLE
Install v0.6.x instead of v0.5.x

### DIFF
--- a/installing/cloud/cloud9.rst
+++ b/installing/cloud/cloud9.rst
@@ -7,7 +7,7 @@ The following are installation instructions for the `Cloud 9 <https://c9.io/>`_ 
 
 .. code:: bash
 	
-	git clone -b v0.5.x https://github.com/NodeBB/NodeBB.git nodebb
+	git clone -b v0.6.x https://github.com/NodeBB/NodeBB.git nodebb
 
 The nodebb command after the git url will create a file called nodebb so you have to CD into the file after you have cloned NodeBB.
 

--- a/installing/cloud/heroku.rst
+++ b/installing/cloud/heroku.rst
@@ -6,7 +6,7 @@ Heroku
 1. Download and install `Heroku Toolbelt <https://toolbelt.heroku.com/>`_ for your operating system
 2. Log into your Heroku account: ``heroku login``
 3. Verify your Heroku account by adding a credit card (at http://heroku.com/verify)
-4. Clone the repository: ``git clone -b v0.5.x https://github.com/NodeBB/NodeBB.git /path/to/repo/clone``
+4. Clone the repository: ``git clone -b v0.6.x https://github.com/NodeBB/NodeBB.git /path/to/repo/clone``
 5. ``cd /path/to/repo/clone``
 6. Install dependencies locally ``npm install --production``
 7. Create the heroku app: ``heroku create``

--- a/installing/cloud/koding.rst
+++ b/installing/cloud/koding.rst
@@ -12,7 +12,7 @@ Koding
 7. Enter your password you used to sign up, if you signed up using Github or another 3rd party, you will need to set one in your Account Settings. Then come back.
 8. Now run the following ``sudo apt-get install python-software-properties python g++ make``
 9. Now we install NodeBBs other dependencies - ``sudo apt-get install redis-server imagemagick``
-10. Next, we clone NodeBB into a NodeBB folder - ``git clone -b v0.5.x https://github.com/NodeBB/NodeBB.git nodebb`` (Optional: Replace nodebb at the end if you want the folder to be a different name)
+10. Next, we clone NodeBB into a NodeBB folder - ``git clone -b v0.6.x https://github.com/NodeBB/NodeBB.git nodebb`` (Optional: Replace nodebb at the end if you want the folder to be a different name)
 11. Now enter the NodeBB folder - ``cd nodebb`` (unless you changed the foldername in the previous step, if you somehow forgot what you called it, run ``ls`` to see the name of the folder)
 12. Now we install all the dependencies of NodeBB - ``npm install`` (could take a minute or two)
 13. Set up nodebb using - ``./nodebb setup``

--- a/installing/cloud/nitrous.rst
+++ b/installing/cloud/nitrous.rst
@@ -13,7 +13,7 @@ https://www.nitrous.io/app#/boxes/new
 
 .. code:: bash
 	
-	wget https://github.com/NodeBB/NodeBB/archive/v0.5.x.zip && unzip NodeBB-v0.5.x.zip && rm NodeBB-v0.5.x.zip && cd NodeBB-v0.5.x
+	wget https://github.com/NodeBB/NodeBB/archive/v0.6.x.zip && unzip NodeBB-v0.6.x.zip && rm NodeBB-v0.6.x.zip && cd NodeBB-v0.6.x
 	
 **Step 4:** NPM Install
 

--- a/installing/cloud/openshift.rst
+++ b/installing/cloud/openshift.rst
@@ -57,7 +57,7 @@ or...
 
 .. code:: bash
 	
-	git pull -s recursive -X theirs upstream v0.5.x && git push
+	git pull -s recursive -X theirs upstream v0.6.x && git push
 	
 **Step 8:** Stop the application
 

--- a/installing/os/arch.rst
+++ b/installing/os/arch.rst
@@ -16,7 +16,7 @@ Next, clone this repository:
 
 .. code:: bash
 
-	$ git clone -b v0.5.x https://github.com/NodeBB/NodeBB.git nodebb
+	$ git clone -b v0.6.x https://github.com/NodeBB/NodeBB.git nodebb
 
 
 Obtain all of the dependencies required by NodeBB:

--- a/installing/os/centos.rst
+++ b/installing/os/centos.rst
@@ -29,7 +29,7 @@ Next, clone the NodeBB repository:
 .. code:: bash
 
 	cd /path/to/nodebb/install/location
-	git clone -b v0.5.x https://github.com/NodeBB/NodeBB nodebb
+	git clone -b v0.6.x https://github.com/NodeBB/NodeBB nodebb
 	
 **Note: To clone the master branch you can use the same command with out the "-b" option.
 

--- a/installing/os/debian.rst
+++ b/installing/os/debian.rst
@@ -139,7 +139,7 @@ Next clone this repository :
 .. code:: bash
 
 	$ cd /path/to/nodebb/install/location
-	$ git clone -b v0.5.x https://github.com/NodeBB/NodeBB.git nodebb
+	$ git clone -b v0.6.x https://github.com/NodeBB/NodeBB.git nodebb
 
 Now we are going to install all dependencies for NodeBB via NPM :
 

--- a/installing/os/osx-mavericks.rst
+++ b/installing/os/osx-mavericks.rst
@@ -31,7 +31,7 @@ Clone NodeBB repo:
 
 .. code:: bash
 
-    git clone -b v0.5.x https://github.com/NodeBB/NodeBB.git
+    git clone -b v0.6.x https://github.com/NodeBB/NodeBB.git
 
 Enter directory: 
 

--- a/installing/os/smartos.rst
+++ b/installing/os/smartos.rst
@@ -88,7 +88,7 @@ Installation
 
     .. code:: bash
 
-        $ git clone -b v0.5.x https://github.com/NodeBB/NodeBB.git nodebb
+        $ git clone -b v0.6.x https://github.com/NodeBB/NodeBB.git nodebb
 
 5. Install NodeBB's npm dependencies:
 

--- a/installing/os/ubuntu.rst
+++ b/installing/os/ubuntu.rst
@@ -27,7 +27,7 @@ Next, clone this repository:
 
 .. code:: bash
 
-	$ git clone -b v0.5.x https://github.com/NodeBB/NodeBB.git nodebb
+	$ git clone -b v0.6.x https://github.com/NodeBB/NodeBB.git nodebb
 
 
 Obtain all of the dependencies required by NodeBB:

--- a/installing/os/windows8.rst
+++ b/installing/os/windows8.rst
@@ -29,7 +29,7 @@ Open Git Shell, and type the following commands. Clone NodeBB repo:
 
 .. code:: bash
 
-    git clone -b v0.5.x https://github.com/NodeBB/NodeBB.git
+    git clone -b v0.6.x https://github.com/NodeBB/NodeBB.git
 
 Enter directory: 
 


### PR DESCRIPTION
Since 0.6.0 is released and stable, shouldn't the docs direct users to install from 0.6.x ?