### PR TITLE
removed the dbsearch from this step

### DIFF
--- a/installing/cloud/heroku.rst
+++ b/installing/cloud/heroku.rst
@@ -26,7 +26,6 @@ Heroku
 
         "dependencies": {
             ...
-            "nodebb-plugin-dbsearch": "0.0.10",
             "redis": "~0.10.1",
             "connect-redis": "~2.0.0"
         },


### PR DESCRIPTION
....since it seems the package.so already has that module in the dependencies, requiring higher version