### PR TITLE
reference v0.8.x for all install docs

### DIFF
--- a/installing/cloud/cloud9.rst
+++ b/installing/cloud/cloud9.rst
@@ -6,39 +6,39 @@ The following are installation instructions for the `Cloud 9 <https://c9.io/>`_ 
 **Step 1:** Clone NodeBB into a new workspace from GitHub. You can use the following command from the terminal:
 
 .. code:: bash
-	
-	git clone -b v0.7.x https://github.com/NodeBB/NodeBB.git nodebb
+
+	git clone -b v0.8.x https://github.com/NodeBB/NodeBB.git nodebb
 
 The nodebb command after the git url will create a file called nodebb so you have to CD into the file after you have cloned NodeBB.
 
 **Step 2:** Install redis with Cloud9's package manager
 
 .. code:: bash
-	
+
 	nada-nix install redis
 
 **Step 3:** Run your redis server on port 16379 - port 6379 tends to be already used on Cloud 9. The "&" makes the command run in the background. You can always terminate the process later. $IP is a Cloud 9 system variable containing the global ip of your server instance.
 
 .. code:: bash
-	
+
 	redis-server --port 16379 --bind $IP &
 
 **Step 4:** Find out your instance's ip address so NodeBB can bind to it correctly. This is one of Cloud 9's demands and seems to be the only way it will work. You can't use $IP in your config.json either (which means you can't enter $IP in the node app --setup).
 
 .. code:: bash
-	
+
 	echo $IP
 
 **Step 5:** Install NodeBB and it's dependencies:
 
 .. code:: bash
-	
+
 	npm install
 
 **Step 6:** Run the nodebb setup utility:
 
 .. code:: bash
-	
+
 	node app --setup
 
 URL of this installation should be set to 'http://workspace_name-c9-username.c9.io', replacing workspace_name with your workspace name and username with your username. Note that as NodeBB is currently using unsecure http for loading jQuery you will find it much easier using http:// instead of https:// for your base url. Otherwise jQuery won't load and NodeBB will break.
@@ -60,7 +60,7 @@ First-time set-up will also require an Admin name, email address and password to
 And you're good to go! Don't use the Run button at the top if the IDE, it has been a little buggy for me. Besides, you're better off using the command line anyway. Run:
 
 .. code:: bash
-	
+
 	node app
 
 And then open http://workspace_name-c9-username.c9.io in your browser.
@@ -68,8 +68,8 @@ And then open http://workspace_name-c9-username.c9.io in your browser.
 Troubleshooting
 ---------------
 
-A common problem is that the database hasn't been started. Make sure you have set Redis up correctly and ran 
+A common problem is that the database hasn't been started. Make sure you have set Redis up correctly and ran
 
 .. code:: bash
-	
+
 	redis-server --port 16379 --bind $IP

--- a/installing/cloud/heroku.rst
+++ b/installing/cloud/heroku.rst
@@ -6,7 +6,7 @@ Heroku
 1. Download and install `Heroku Toolbelt <https://toolbelt.heroku.com/>`_ for your operating system
 2. Log into your Heroku account: ``heroku login``
 3. Verify your Heroku account by adding a credit card (at http://heroku.com/verify)
-4. Clone the repository: ``git clone -b v0.7.x https://github.com/NodeBB/NodeBB.git /path/to/repo/clone``
+4. Clone the repository: ``git clone -b v0.8.x https://github.com/NodeBB/NodeBB.git /path/to/repo/clone``
 5. ``cd /path/to/repo/clone``
 6. Install dependencies locally ``npm install --production``
 7. Create the heroku app: ``heroku create``
@@ -38,7 +38,7 @@ Heroku
 
 	git rm npm-shrinkwrap.json && git add -f Procfile config.json package.json && git commit -am "adding Procfile and configs for Heroku"
 
-13. Push to heroku: ``git push -u heroku v0.7.x:master``
+13. Push to heroku: ``git push -u heroku v0.8.x:master``
     * Ensure that a proper SSH key was added to your account, otherwise the push will not succeed!
 14. Initialise a single dyno: ``heroku ps:scale web=1``
 15. Visit your app!

--- a/installing/cloud/koding.rst
+++ b/installing/cloud/koding.rst
@@ -12,11 +12,11 @@ Koding
 7. Enter your password you used to sign up, if you signed up using Github or another 3rd party, you will need to set one in your Account Settings. Then come back.
 8. Now run the following ``sudo apt-get install python-software-properties python g++ make``
 9. Now we install NodeBBs other dependencies - ``sudo apt-get install redis-server imagemagick``
-10. Next, we clone NodeBB into a NodeBB folder - ``git clone -b v0.7.x https://github.com/NodeBB/NodeBB.git nodebb`` (Optional: Replace nodebb at the end if you want the folder to be a different name)
+10. Next, we clone NodeBB into a NodeBB folder - ``git clone -b v0.8.x https://github.com/NodeBB/NodeBB.git nodebb`` (Optional: Replace nodebb at the end if you want the folder to be a different name)
 11. Now enter the NodeBB folder - ``cd nodebb`` (unless you changed the foldername in the previous step, if you somehow forgot what you called it, run ``ls`` to see the name of the folder)
 12. Now we install all the dependencies of NodeBB - ``npm install`` (could take a minute or two)
 13. Set up nodebb using - ``./nodebb setup``
-14. The first setup question will ask for the domain name, this will vary, do not use localhost. Your domain name/Access URI is found on the left sidepanel by clicking the small icon to the right of your koding-vm-ID underneath VMS (it's a circle with 3 dots inside). 
+14. The first setup question will ask for the domain name, this will vary, do not use localhost. Your domain name/Access URI is found on the left sidepanel by clicking the small icon to the right of your koding-vm-ID underneath VMS (it's a circle with 3 dots inside).
 15. Complete the setup (defaults after the domain name are fine to accept, so press enter a few times until you get to "Create an Admin"
 16. Create an Admin Username and password etc, it will then create categories and other things that make NodeBB awesome.
 17. Now we can start NodeBB - ``./nodebb start``

--- a/installing/cloud/nitrous.rst
+++ b/installing/cloud/nitrous.rst
@@ -12,15 +12,15 @@ https://www.nitrous.io/app#/boxes/new
 **Step 3:** Get the files of NodeBB, unzip, delete master.zip and cd to the folder
 
 .. code:: bash
-	
-	wget https://github.com/NodeBB/NodeBB/archive/v0.7.x.zip && unzip NodeBB-v0.7.x.zip && rm NodeBB-v0.7.x.zip && cd NodeBB-v0.7.x
-	
+
+	wget https://github.com/NodeBB/NodeBB/archive/v0.8.x.zip && unzip NodeBB-v0.8.x.zip && rm NodeBB-v0.8.x.zip && cd NodeBB-v0.8.x
+
 **Step 4:** NPM Install
 
 .. code:: bash
 
   npm install
-  
+
 **Step 5:** Install Redis
 
 .. code:: bash
@@ -30,8 +30,8 @@ https://www.nitrous.io/app#/boxes/new
 **Step 6:** Setup NodeBB
 
 .. code:: bash
-	
-	./nodebb setup 
+
+	./nodebb setup
 
 Leave everything as default but you can change yourself.
 
@@ -40,7 +40,7 @@ I recommend the port number to bind : 8080
 **Step 14:** And the last one, start NodeBB
 
 .. code:: bash
-	
+
 	./nodebb start
 
 And then open the "Preview URI" without port if you have put for port : 8080.

--- a/installing/cloud/openshift.rst
+++ b/installing/cloud/openshift.rst
@@ -84,7 +84,7 @@ cd nodebb && git remote add upstream -m master https://github.com/NodeBB/NodeBB.
 
 **Step 14:** Then pull files from NodeBB's repository.
 ```
-git pull -s recursive -X theirs upstream v0.7.x
+git pull -s recursive -X theirs upstream v0.8.x
 ```
 
 **Step 15:** Now you will need to commit and push files to your application's repository. Replace `message` with your message. It will take a while to finish, though.
@@ -140,7 +140,7 @@ Note
 Starting, stopping, reloading, or restarting NodeBB now works on Openshift. Be sure you always do this before doing it. (Replace `[string]` to a valid string.)
 
 .. code:: bash
-	
+
 	rhc app ssh -a nodebb
     cd ~/app-root/repo
     ./nodebb [string]

--- a/installing/os/arch.rst
+++ b/installing/os/arch.rst
@@ -16,7 +16,7 @@ Next, clone this repository:
 
 .. code:: bash
 
-	$ git clone -b v0.7.x https://github.com/NodeBB/NodeBB.git nodebb
+	$ git clone -b v0.8.x https://github.com/NodeBB/NodeBB.git nodebb
 
 
 Obtain all of the dependencies required by NodeBB:
@@ -35,7 +35,7 @@ Initiate the setup script by running the app with the ``setup`` flag:
 	$ ./nodebb setup
 
 
-The default settings are for a local server running on the default port, with a redis store on the same machine/port. 
+The default settings are for a local server running on the default port, with a redis store on the same machine/port.
 
 Lastly, we run the forum.
 

--- a/installing/os/centos.rst
+++ b/installing/os/centos.rst
@@ -5,15 +5,15 @@ CentOS 6/7
 First we should make sure that CentOS is up to date, we can to so using this command:
 
 .. code:: bash
-	
+
 	yum -y update
 
 **If your on CentOS 7, you will need to install the epel release, you can do so using the following command:
 
 .. code:: bash
-	
+
 	yum -y install epel-release
-	
+
 
 Now, we install our base software stack:
 
@@ -29,14 +29,14 @@ Next, clone the NodeBB repository:
 .. code:: bash
 
 	cd /path/to/nodebb/install/location
-	git clone -b v0.7.x https://github.com/NodeBB/NodeBB nodebb
-	
+	git clone -b v0.8.x https://github.com/NodeBB/NodeBB nodebb
+
 **Note: To clone the master branch you can use the same command with out the "-b" option.
 
 After cloning the repository, obtain all of the dependencies required by NodeBB:
 
 .. code:: bash
-      
+
       cd nodebb
       npm install
 
@@ -47,10 +47,10 @@ Initiate the setup script by running the app with the ``setup`` flag:
 	  ./nodebb setup
 
 
-The default settings are for a local server running on the default port, with a redis store on the same machine/port. 
+The default settings are for a local server running on the default port, with a redis store on the same machine/port.
 
 Lastly, we run the forum.
-  
+
 .. code:: bash
 
 	 ./nodebb start

--- a/installing/os/debian.rst
+++ b/installing/os/debian.rst
@@ -139,7 +139,7 @@ Next clone this repository :
 .. code:: bash
 
 	$ cd /path/to/nodebb/install/location
-	$ git clone -b v0.7.x https://github.com/NodeBB/NodeBB.git nodebb
+	$ git clone -b v0.8.x https://github.com/NodeBB/NodeBB.git nodebb
 
 Now we are going to install all dependencies for NodeBB via NPM :
 
@@ -155,11 +155,11 @@ Install NodeBB by running the app with `--setup` flag :
 	$ ./nodebb setup
 
 
-1. `URL of this installation` is either your public ip address or your domain name pointing to that ip address.  
-    **Example:** ``http://0.0.0.0`` or ``http://example.org``  
+1. `URL of this installation` is either your public ip address or your domain name pointing to that ip address.
+    **Example:** ``http://0.0.0.0`` or ``http://example.org``
 
-2. ``Port number of your NodeBB`` is the port needed to access your site:  
-    **Note:** If you do not proxy your port with something like nginx then port 80 is recommended for production.  
+2. ``Port number of your NodeBB`` is the port needed to access your site:
+    **Note:** If you do not proxy your port with something like nginx then port 80 is recommended for production.
 3. If you used the above steps to setup your redis-server then use the default redis settings.
 
 And after all.. let's run the NodeBB forum

--- a/installing/os/osx-mavericks.rst
+++ b/installing/os/osx-mavericks.rst
@@ -20,9 +20,9 @@ Install redis with homebrew:
 .. code::
 
   brew install redis
-  
+
 Start redis server, in your terminal enter:
-  
+
 .. code::
 
   redis-server
@@ -31,9 +31,9 @@ Clone NodeBB repo:
 
 .. code:: bash
 
-    git clone -b v0.7.x https://github.com/NodeBB/NodeBB.git
+    git clone -b v0.8.x https://github.com/NodeBB/NodeBB.git
 
-Enter directory: 
+Enter directory:
 
 .. code:: bash
 
@@ -53,7 +53,7 @@ Run interactive installation:
 
 You may leave all of the options as default.
 
-And you're done! After the installation, run 
+And you're done! After the installation, run
 
 .. code:: bash
 

--- a/installing/os/smartos.rst
+++ b/installing/os/smartos.rst
@@ -6,9 +6,9 @@ Requirements
 
 NodeBB requires the following software to be installed:
 
-* Node.js (version 0.10 or greater, instructions below).  
-* Redis (version 2.6 or greater, instructions below) or MongoDB (version 2.6 or greater).  
-* nginx (version 1.3.13 or greater, **only if** intending to use nginx to proxy requests to a NodeBB server).  
+* Node.js (version 0.10 or greater, instructions below).
+* Redis (version 2.6 or greater, instructions below) or MongoDB (version 2.6 or greater).
+* nginx (version 1.3.13 or greater, **only if** intending to use nginx to proxy requests to a NodeBB server).
 
 Server Access
 ----------------
@@ -17,17 +17,17 @@ Server Access
 
 2. Select: ``Create Instance``
 
-3. Create the newest ``smartos nodejs`` image.  
+3. Create the newest ``smartos nodejs`` image.
 
     **Note:** The following steps have been tested with images: ``smartos nodejs 13.1.0`` ``smartos nodejs 13.2.3``
 
 4. Wait for your instance to show ``Running`` then click on its name.
 
-5. Find your ``Login`` and admin password. If the ``Credentials`` section is missing, refresh the webpage.  
+5. Find your ``Login`` and admin password. If the ``Credentials`` section is missing, refresh the webpage.
 
-    **Example:** ``ssh root@0.0.0.0`` ``A#Ca{c1@3`` 
+    **Example:** ``ssh root@0.0.0.0`` ``A#Ca{c1@3``
 
-6. SSH into your server as the admin not root: ``ssh admin@0.0.0.0``  
+6. SSH into your server as the admin not root: ``ssh admin@0.0.0.0``
 
     **Note:** For Windows users that do not have ssh installed, here is an option: `Cygwin.com <http://cygwin.com>`_
 
@@ -48,23 +48,23 @@ Installation
         $ pkgin search *failed-name*
         $ sudo pkgin install *available-name*
 
-2. **If needed** setup a redis-server with default settings as a service (automatically starts and restarts):  
-    
+2. **If needed** setup a redis-server with default settings as a service (automatically starts and restarts):
+
     If you want to use MongoDB, LevelDB, or another database instead of Redis please look at the :doc:`Configuring Databases <../../configuring/databases>` section.
-    
-    **Note:** These steps quickly setup a redis server but do not fine-tuned it for production.  
-    
-    **Note:** If you manually ran ``redis-server`` then exit out of it now.  
+
+    **Note:** These steps quickly setup a redis server but do not fine-tuned it for production.
+
+    **Note:** If you manually ran ``redis-server`` then exit out of it now.
 
     .. code:: bash
 
         $ svcadm enable redis
         $ svcs svc:/pkgsrc/redis:default
     **Note:** If the STATE is maintenance then:
-    
+
     .. code:: bash
 
-        $ scvadm clear redis  
+        $ scvadm clear redis
 
     *-* To shut down your redis-server and keep it from restarting:
 
@@ -88,7 +88,7 @@ Installation
 
     .. code:: bash
 
-        $ git clone -b v0.7.x https://github.com/NodeBB/NodeBB.git nodebb
+        $ git clone -b v0.8.x https://github.com/NodeBB/NodeBB.git nodebb
 
 5. Install NodeBB's npm dependencies:
 
@@ -97,37 +97,37 @@ Installation
         $ cd nodebb
         $ npm install
 
-6. Run NodeBB's setup script:  
+6. Run NodeBB's setup script:
 
     .. code:: bash
 
         $ ./nodebb setup
 
-    a. ``URL used to access this NodeBB`` is either your public ip address from your ssh ``Login`` or your domain name pointing to that ip address.  
+    a. ``URL used to access this NodeBB`` is either your public ip address from your ssh ``Login`` or your domain name pointing to that ip address.
 
-        **Example:** ``http://0.0.0.0`` or ``http://example.org``  
+        **Example:** ``http://0.0.0.0`` or ``http://example.org``
 
-    b. ``Port number of your NodeBB`` is the port needed to access your site:  
+    b. ``Port number of your NodeBB`` is the port needed to access your site:
 
-        **Note:** If you do not proxy your port with something like nginx then port 80 is recommended for production.  
-    
+        **Note:** If you do not proxy your port with something like nginx then port 80 is recommended for production.
+
     c. ``Please enter a NodeBB secret`` - Do not email this or post publicly.
-    
-    d. ``IP or Hostname to bind to`` - Use default unless your server requires otherwise.
-    
-    e. If you used the above steps to setup your redis-server then use the default redis settings.  
 
-7. Start NodeBB process manually:  
-    **Note:** This should not be used for production but instead create a deamon manually, use Forever, or use Supervisor. :doc:`Take a look at the options here <../../running/index>`.  
+    d. ``IP or Hostname to bind to`` - Use default unless your server requires otherwise.
+
+    e. If you used the above steps to setup your redis-server then use the default redis settings.
+
+7. Start NodeBB process manually:
+    **Note:** This should not be used for production but instead create a deamon manually, use Forever, or use Supervisor. :doc:`Take a look at the options here <../../running/index>`.
 
     .. code:: bash
 
         $ node app
 
-8. Visit your app!  
+8. Visit your app!
     **Example:** With a port of 4567: ``http://0.0.0.0:4567`` or ``http://example.org:4567``
 
-    **Note:** With port 80 the ``:80`` does not need to be entered.  
+    **Note:** With port 80 the ``:80`` does not need to be entered.
 
 **Note:** If these instructions are unclear or if you run into trouble, please let us know by `filing an issue <https://github.com/NodeBB/NodeBB/issues>`_.
 

--- a/installing/os/ubuntu.rst
+++ b/installing/os/ubuntu.rst
@@ -27,7 +27,7 @@ Next, clone this repository:
 
 .. code:: bash
 
-	$ git clone -b v0.7.x https://github.com/NodeBB/NodeBB.git nodebb
+	$ git clone -b v0.8.x https://github.com/NodeBB/NodeBB.git nodebb
 
 
 Obtain all of the dependencies required by NodeBB:
@@ -54,7 +54,7 @@ Start the NodeBB Web Installer, and continue setup at http://127.0.0.1:4567.
 	$ ./nodebb setup
 
 
-The default settings are for a local server running on the default port, with a redis store on the same machine/port. 
+The default settings are for a local server running on the default port, with a redis store on the same machine/port.
 
 Lastly, we run the forum.
 

--- a/installing/os/windows8.rst
+++ b/installing/os/windows8.rst
@@ -29,9 +29,9 @@ Open Git Shell, and type the following commands. Clone NodeBB repo:
 
 .. code:: bash
 
-    git clone -b v0.7.x https://github.com/NodeBB/NodeBB.git
+    git clone -b v0.8.x https://github.com/NodeBB/NodeBB.git
 
-Enter directory: 
+Enter directory:
 
 .. code:: bash
 
@@ -51,7 +51,7 @@ Run interactive installation:
 
 You may leave all of the options as default.
 
-And you're done! After the installation, run 
+And you're done! After the installation, run
 
 .. code:: bash
 


### PR DESCRIPTION
I'm not sure if NodeBB wants to start advertising the use of 0.8.x (since it was just released, as of writing this PR, 7 hours ago) but here are the updated docs, pointing to 0.8.x.

Sorry for the big diff, there were quite a lot of trailing white spaces+trailing tabs and my editor decided to it was going to remove them all.

I ran `make install html`, inspected the affected areas and everything looks good on my end.