### PR TITLE
Add information about quickstart

### DIFF
--- a/installing/cloud/openshift.rst
+++ b/installing/cloud/openshift.rst
@@ -1,9 +1,11 @@
 Openshift PaaS
 ===========
 
-The following are installation instructions for the `Openshift <http://openshift.com>` PaaS. Before starting, you need to install Red Hat's rhc command line at https://developers.openshift.com/en/managing-client-tools.html.
+**Notice: ** A quickstart has been made to handle much of the below by using openshift's environment variables. If you're just getting started please take a look at <a href="https://github.com/ahwayakchih/openshift-nodebb" target="_blank">https://github.com/ahwayakchih/openshift-nodebb</a>
 
-**Step 1:** Go to https://openshift.redhat.com/app/console/applications and then create an application.
+The following are installation instructions for the `Openshift <http://openshift.com>` PaaS. Before starting, you need to install Red Hat's rhc command line at <a href="https://developers.openshift.com/en/managing-client-tools.html" target="_blank">https://developers.openshift.com/en/managing-client-tools.html</a>
+
+**Step 1:** Go to <a href="https://openshift.redhat.com/app/console/applications" target="_blank">https://openshift.redhat.com/app/console/applications</a> and then create an application.
 
 **Step 2:** Scroll down and choose Node.js 0.10 in "Other types". Then click 'Next'.
 
@@ -46,7 +48,7 @@ exit
 
 Note: You might have to type 'exit' once, and then again to exit SSH completely.
 
-**Step 11:** Go back to https://openshift.redhat.com/app/console/applications and then click NodeBB application. Copy the URL address from "Scoure Code."
+**Step 11:** Go back to <a href="https://openshift.redhat.com/app/console/applications" target="_blank">https://openshift.redhat.com/app/console/applications</a> and then click NodeBB application. Copy the URL address from "Scoure Code."
 A similar scoure code URL address should be this: ssh://[code]@nodebb-[namespace].rhcloud.com/~/git/nodebb.git/
 
 **Step 12:** Go back to terminal. Paste the following command and then paste the URL address.
@@ -58,9 +60,12 @@ Note: If it exists, check to make sure you do not have more than four files. If 
 
 Note: This will create NodeBB folder on your computer, usually ~/users/[name]/NodeBB
 
-**Step 13:** Then cd to NodeBB folder on your computer. And you will need to clone NodeBB from Github to your application by using this command. The default command git clone will not work with Openshift, unless you're in SSH.
+**Step 13:** Then cd to NodeBB folder on your computer. And you will need to clone NodeBB from Github to your application by using this command. The default command git clone will not work with Openshift, unless you're in SSH. You may split up this command into two parts if you needed to clone your repository to another part of your computer start git bash from there.
 ```
 cd nodebb && git remote add upstream -m master https://github.com/NodeBB/NodeBB.git
+or
+cd nodebb
+git remote add upstream -m master https://github.com/NodeBB/NodeBB.git
 ```
 
 **Step 14:** Then pull files from NodeBB's repository.


### PR DESCRIPTION
A quickstart for nodebb has been put into development. Currently verified compatible with v.0.9.x, other previous versions may be installed by pulling different versions of nodebb. Requires no ssh instructions.

Also turned links into actual links for website visualization of markdown.