### PR TITLE
Remove all! trailing / in example config for nginx

### DIFF
--- a/configuring/proxies/nginx.md
+++ b/configuring/proxies/nginx.md
@@ -41,7 +41,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy true;
 
-        proxy_pass http://127.0.0.1:4567/;
+        proxy_pass http://127.0.0.1:4567;
         proxy_redirect off;
 
         # Socket.IO Support
@@ -121,7 +121,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy true;
 
-        proxy_pass http://127.0.0.1:4567/;
+        proxy_pass http://127.0.0.1:4567;
         proxy_redirect off;
 
         # Socket.IO Support

--- a/configuring/proxies/nginx.rst
+++ b/configuring/proxies/nginx.rst
@@ -135,7 +135,7 @@ Below is an nginx configuration which uses SSL.
             proxy_set_header Host $http_host;
             proxy_set_header X-NginX-Proxy true;
 
-            proxy_pass http://127.0.0.1:4567/;
+            proxy_pass http://127.0.0.1:4567;
             proxy_redirect off;
 
             # Socket.IO Support


### PR DESCRIPTION
I removed all trailing / in the example config for nginx.