### PR TITLE
Fix Apache mod_headers install

### DIFF
--- a/configuring/proxies/apache.rst
+++ b/configuring/proxies/apache.rst
@@ -9,7 +9,7 @@ Enable the necessary modules
 1. sudo a2enmod proxy
 2. sudo a2enmod proxy_http
 3. sudo a2enmod rewrite
-4. sudo a2enmod mod_headers
+4. sudo a2enmod headers
 
 Add the config to Apache
 -----------------------------


### PR DESCRIPTION
When using `a2enmod` you don't add `mod_`