### PR TITLE
added websocket proxy to apache configuration.

### DIFF
--- a/configuring/proxies/apache.rst
+++ b/configuring/proxies/apache.rst
@@ -8,8 +8,9 @@ Enable the necessary modules
 
 1. sudo a2enmod proxy
 2. sudo a2enmod proxy_http
-3. sudo a2enmod rewrite
-4. sudo a2enmod mod_headers
+3. sudo a2enmod proxy_wstunnel
+4. sudo a2enmod rewrite
+5. sudo a2enmod mod_headers
 
 Add the config to Apache
 -----------------------------


### PR DESCRIPTION
Installing nodebb behind apache2.4 appears to also require
the websocket be proxied as well, without the proxy_wstunnel
module loaded the app seems unable to connect to the /socket.io/
end point, and the apache logs produce the following error:

No protocol handler was valid for the URL /socket.io/.
If you are using a DSO version of mod_proxy,
make sure the proxy submodules are included in the
configuration using LoadModule