### PR TITLE
Update osx-mavericks.rst

### DIFF
--- a/installing/os/osx-mavericks.rst
+++ b/installing/os/osx-mavericks.rst
@@ -53,7 +53,7 @@ Run interactive installation:
 
     ./nodebb setup
 
-You may leave all of the options as default.
+You may leave all of the options as default, except "Which database to use (mongo)", which you should answer with "redis"
 
 And you're done! After the installation, run
 


### PR DESCRIPTION
Instructions start with setting up redis but the default is mongo as of v1.4.6. also it looks like the weekly branch doesn't exist anymore